### PR TITLE
Fix file-prompt returning relative path in multi-directory setup

### DIFF
--- a/consult-denote.el
+++ b/consult-denote.el
@@ -129,9 +129,11 @@ Return the absolute path to the matching file."
          (files (denote-directory-files
                  (or denote-file-prompt-use-files-matching-regexp files-matching-regexp)
                  :omit-current nil nil roots))
-         (relative-files (mapcar
-                          (lambda (file)
-                            (denote-get-file-name-relative-to-denote-directory file))
+         (relative-files (if single-dir-p
+                            (mapcar
+                             (lambda (file)
+                               (denote-get-file-name-relative-to-denote-directory file))
+                             files)
                           files))
          (prompt (if single-dir-p
                      (format "%s: " (or prompt-text "Select FILE"))


### PR DESCRIPTION
Fixes #23.

When `denote-directory` is a list of multiple directories, `consult-denote-file-prompt` always relativized candidate paths but only re-expanded them in the single-directory case. In the multi-directory case the relative path was returned as-is, causing callers like `denote-link` to fail with "The linked file does not exist".

This mirrors the stock `denote-file-prompt` behavior: only relativize when there is a single denote directory; otherwise keep absolute paths.